### PR TITLE
Add link to track search feature

### DIFF
--- a/htmlgenerators.py
+++ b/htmlgenerators.py
@@ -2,6 +2,8 @@ import urllib
 from bottle import FormsDict
 import datetime
 from urihandler import compose_querystring
+import urllib.parse
+from doreah.settings import get_settings
 
 
 # returns the proper column(s) for an artist or track
@@ -16,7 +18,10 @@ def entity_column(element,counting=[],image=None):
 		# track
 	#	html += "<td class='artists'>" + html_links(element["artists"]) + "</td>"
 	#	html += "<td class='title'>" + html_link(element) + "</td>"
-		html += "<td class='track'><span class='artist_in_trackcolumn'>" + html_links(element["artists"]) + "</span> – " + html_link(element) + "</td>"
+		html += "<td class='track'><span class='artist_in_trackcolumn'>"
+		if get_settings("TRACK_SEARCH_PROVIDER") not in [None,"ASK", ""]:
+			html += trackSearchLink(element)
+		html += html_links(element["artists"]) + "</span> – " + html_link(element) + "</td>"
 	else:
 		# artist
 		html += "<td class='artist'>" + html_link(element)
@@ -73,6 +78,31 @@ def trackLink(track):
 	return html_link(track)
 	#artists,title = track["artists"],track["title"]
 	#return "<a href='/track?title=" + urllib.parse.quote(title) + "&" + "&".join(["artist=" + urllib.parse.quote(a) for a in artists]) + "'>" + title + "</a>"
+
+def trackSearchLink(track):
+	searchProvider = get_settings("TRACK_SEARCH_PROVIDER")
+	link = "<a class='trackProviderSearch' href='"
+	if searchProvider == "YouTube":
+		link += "https://www.youtube.com/results?search_query="
+	elif searchProvider == "YouTube Music":
+		link += "https://music.youtube.com/search?q="
+	elif searchProvider == "Google Play Music":
+		link += "https://play.google.com/music/listen#/srs/"
+	elif searchProvider == "Spotify":
+		link += "https://open.spotify.com/search/results/"
+	elif searchProvider == "Tidal":
+		link += "https://listen.tidal.com/search/tracks?q="
+	elif searchProvider == "SoundCloud":
+		link += "https://soundcloud.com/search?q="
+	elif searchProvider == "Amazon Music":
+		link += "https://music.amazon.com/search/"
+	elif searchProvider == "Deezer":
+		link += "https://www.deezer.com/search/"
+	else:
+		link += "https://www.google.com/search?q=" # ¯\_(ツ)_/¯
+
+	link += urllib.parse.quote(", ".join(track["artists"]) + " - " + track["title"]) + "'>&#127925;</a>"
+	return link
 
 #def scrobblesTrackLink(artists,title,timekeys,amount=None,pixels=None):
 def scrobblesTrackLink(track,timekeys,amount=None,percent=None):

--- a/settings/default.ini
+++ b/settings/default.ini
@@ -17,6 +17,10 @@ SPOTIFY_API_SECRET = "ASK"
 CACHE_EXPIRE_NEGATIVE = 30	# after how many days negative results should be tried again
 CACHE_EXPIRE_POSITIVE = 300	# after how many days positive results should be refreshed
 
+# Can be 'YouTube', 'YouTube Music', 'Google Play Music', 'Spotify', 'Tidal', 'SoundCloud', 'Deezer', 'Amazon Music'
+# Leave empty to disable
+TRACK_SEARCH_PROVIDER = "YouTube"
+
 [Database]
 
 DB_CACHE_SIZE = 8192		# how many MB on disk each database cache should have available.

--- a/website/css/maloja.css
+++ b/website/css/maloja.css
@@ -493,7 +493,10 @@ table.list td.track span.artist_in_trackcolumn {
 	color:#bbb;
 }
 
-
+table.list td.track a.trackProviderSearch {
+	margin-right: 5px;
+	padding: 0 10px;
+}
 
 
 


### PR DESCRIPTION
Hi! I've been happily using Maloja for a couple weeks now. This adds a link to the search results for each track on a provider of choice, set using the `TRACK_SEARCH_PROVIDER` settings field which can be one of a handful of services.

This is [running on my instance](https://scrobbles.z0.lt/) if you'd like to take a look.

I don't normally write Python, so you'll have to let me know if I've done anything odd.

Possible future enhancements could link directly to the track itself, adding support for services where you can't just plop the track into a search URL (iTunes/Apple Music) [Rosey The Bot's source](https://github.com/AH-Dietrich/rosey-the-bot-open) looks like it could be a decent place to start.

![image](https://user-images.githubusercontent.com/904055/63465780-f554e780-c42f-11e9-9891-8f245ae5a423.png)
