### PR TITLE
Optionally display tiles in artist & track chart pages

### DIFF
--- a/settings/default.ini
+++ b/settings/default.ini
@@ -41,6 +41,9 @@ DEFAULT_RANGE_CHARTS_TRACKS = year
 # can be day, week, month, year
 DEFAULT_STEP_PULSE = month
 
+# display top tiles on artist and chart pages
+CHARTS_DISPLAY_TILES = false
+
 [Fluff]
 
 # how many scrobbles a track needs to aquire this status

--- a/website/charts_artists.html
+++ b/website/charts_artists.html
@@ -11,7 +11,7 @@
 		<table class="top_info">
 			<tr>
 				<td class="image">
-					<div style="background-image:url('KEY_TOPARTIST_IMAGEURL')"></div>
+					KEY_TOPARTIST_IMAGEDIV
 				</td>
 				<td class="text">
 					<h1>Artist Charts</h1><a href="/top_artists"><span>View #1 Artists</span></a><br/>
@@ -24,6 +24,9 @@
 			</tr>
 		</table>
 
+		<span class="stat_module_topartists">
+		KEY_ARTISTCHART
+		</span>
 
 		KEY_ARTISTLIST
 

--- a/website/charts_artists.py
+++ b/website/charts_artists.py
@@ -4,8 +4,9 @@ import urllib
 def instructions(keys):
 	from utilities import getArtistImage
 	from urihandler import compose_querystring, uri_to_internal
-	from htmlmodules import module_artistcharts, module_filterselection
+	from htmlmodules import module_artistcharts, module_filterselection, module_artistcharts_tiles
 	from malojatime import range_desc
+	from doreah.settings import get_settings
 
 
 	_, timekeys, _, amountkeys = uri_to_internal(keys)
@@ -14,6 +15,9 @@ def instructions(keys):
 
 	html_filterselector = module_filterselection(keys)
 
+	topartists = ""
+	if get_settings("CHARTS_DISPLAY_TILES"):
+		topartists = module_artistcharts_tiles(timerange=timekeys["timerange"])
 
 
 	html_charts, rep = module_artistcharts(**amountkeys,**timekeys)
@@ -23,10 +27,16 @@ def instructions(keys):
 	else:
 		imgurl = ""
 
+	imgdiv = '<div style="background-image:url('+imgurl+')"></div>'
+	if get_settings("CHARTS_DISPLAY_TILES"):
+		imgdiv = ""
+
 	pushresources = [{"file":imgurl,"type":"image"}] if imgurl.startswith("/") else []
 
 
-	replace = {"KEY_TOPARTIST_IMAGEURL":imgurl,
+	replace = {
+	"KEY_TOPARTIST_IMAGEDIV":imgdiv,
+	"KEY_ARTISTCHART":topartists,
 	"KEY_ARTISTLIST":html_charts,
 	"KEY_RANGE":limitstring,
 	"KEY_FILTERSELECTOR":html_filterselector}

--- a/website/charts_tracks.html
+++ b/website/charts_tracks.html
@@ -10,7 +10,7 @@
 		<table class="top_info">
 			<tr>
 				<td class="image">
-					<div style="background-image:url('KEY_TOPARTIST_IMAGEURL')"></div>
+					KEY_TOPARTIST_IMAGEDIV
 				</td>
 				<td class="text">
 					<h1>Track Charts</h1>TOP_TRACKS_LINK<br/>
@@ -22,6 +22,9 @@
 			</tr>
 		</table>
 
+		<span class="stat_module_topartists">
+		KEY_TRACKCHART
+		</span>
 
 		KEY_TRACKLIST
 

--- a/website/charts_tracks.py
+++ b/website/charts_tracks.py
@@ -5,8 +5,9 @@ def instructions(keys):
 	from utilities import getArtistImage, getTrackImage
 	from htmlgenerators import artistLink
 	from urihandler import compose_querystring, uri_to_internal
-	from htmlmodules import module_trackcharts, module_filterselection
+	from htmlmodules import module_trackcharts, module_filterselection, module_trackcharts_tiles
 	from malojatime import range_desc
+	from doreah.settings import get_settings
 
 	filterkeys, timekeys, _, amountkeys = uri_to_internal(keys)
 
@@ -22,6 +23,10 @@ def instructions(keys):
 
 	html_charts, rep = module_trackcharts(**amountkeys,**timekeys,**filterkeys)
 
+	toptracks = ""
+	if get_settings("CHARTS_DISPLAY_TILES"):
+		toptracks = module_trackcharts_tiles(timerange=timekeys["timerange"])
+
 
 	if filterkeys.get("artist") is not None:
 		imgurl = getArtistImage(filterkeys.get("artist"))
@@ -31,6 +36,10 @@ def instructions(keys):
 	else:
 		imgurl = ""
 
+	imgdiv = '<div style="background-image:url('+imgurl+')"></div>'
+	if get_settings("CHARTS_DISPLAY_TILES"):
+		imgdiv = ""
+
 	limitstring += " " + timekeys["timerange"].desc(prefix=True)
 
 	pushresources = [{"file":imgurl,"type":"image"}] if imgurl.startswith("/") else []
@@ -38,7 +47,8 @@ def instructions(keys):
 
 
 	replace = {
-		"KEY_TOPARTIST_IMAGEURL":imgurl,
+		"KEY_TOPARTIST_IMAGEDIV":imgdiv,
+		"KEY_TRACKCHART":toptracks,
 		"KEY_TRACKLIST":html_charts,
 		"KEY_LIMITS":limitstring,
 		"KEY_FILTERSELECTOR":html_filterselector,

--- a/website/css/maloja.css
+++ b/website/css/maloja.css
@@ -226,13 +226,9 @@ div.searchresults table.searchresults_tracks td span:nth-child(1) {
 **
 */
 
-table.top_info td.image {
-	padding:20px;
-	padding-left:0px;
-	padding-top:0px;
-}
-
 table.top_info td.image div {
+	margin-right:20px;
+	margin-bottom:20px;
 	background-size:cover;
 	background-position:center;
 	height:174px;
@@ -241,7 +237,6 @@ table.top_info td.image div {
 
 table.top_info td.text {
 	vertical-align: top;
-    	padding-left: 30px;
 }
 
 table.top_info td.text h1 {
@@ -257,7 +252,10 @@ p.desc a {
 	background-image:url("https://www.last.fm/static/images/lastfm_avatar_twitter.66cd2c48ce03.png");
 }
 
-
+table.top_info + .stat_module_topartists table,
+table.top_info + .stat_module_toptracks table {
+	margin:15px 0;
+}
 
 /*
 **


### PR DESCRIPTION
I added this because I wanted to view the top artist/track tiles for previous time periods. For example, my top artists last month:

![image](https://user-images.githubusercontent.com/904055/64229510-f4a06480-ceb7-11e9-9fcb-39d12a4cc229.png)


This is [live on my instance](https://scrobbles.z0.lt/charts_artists?in=2019/8) if you want to toy around.


Same caveat as my last PR: Not sure this is the best way to do this - I was actually surprised it worked in so little code! I felt the existing top artist image wasn't needed if this feature is enabled.
