### PR TITLE
Remove pip3 and dependencies after installing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,18 @@
-FROM python:3.6-alpine
+FROM python:3-alpine
 
 WORKDIR /usr/src/app
 
-RUN apk update
-RUN apk add gcc libxml2-dev libxslt-dev py3-pip libc-dev linux-headers
-RUN pip3 install psutil
-
-RUN pip3 install malojaserver
+RUN apk add --no-cache --virtual .build-deps \
+    gcc \
+    libxml2-dev \
+    libxslt-dev \
+    py3-pip \
+    libc-dev \
+    linux-headers \
+    && \
+    pip3 install psutil && \
+    pip3 install malojaserver && \
+    apk del .build-deps
 
 EXPOSE 42010
 


### PR DESCRIPTION
This reduces the size of the final image. Also used `apk add --no-cache` instead of `apk update` so the final image does not contain unnecessary repository info.

From ~115MB compressed to ~40MB compressed