### PR TITLE
Reimplement track search provider in jinja templates

### DIFF
--- a/maloja/data_files/settings/default.ini
+++ b/maloja/data_files/settings/default.ini
@@ -34,8 +34,8 @@ CACHE_EXPIRE_POSITIVE = 300	# after how many days positive results should be ref
 THUMBOR_SERVER = None
 THUMBOR_SECRET = ""
 
-# Can be 'YouTube', 'YouTube Music', 'Google Play Music', 'Spotify', 'Tidal', 'SoundCloud', 'Deezer', 'Amazon Music'
-# Omit or set to none to disable
+# Can be 'YouTube', 'YouTube Music', 'Spotify', 'Tidal', 'SoundCloud', 'Deezer', 'Amazon Music', 'Apple'
+# Set to None to disable
 TRACK_SEARCH_PROVIDER = None
 
 [Database]

--- a/maloja/web/jinja/snippets/entityrow.jinja
+++ b/maloja/web/jinja/snippets/entityrow.jinja
@@ -10,6 +10,9 @@
 
 <td class='icon'><div style="background-image:url('{{ img }}')"></div></td>
 {% if "artists" in entity %}
+	{% if settings('TRACK_SEARCH_PROVIDER') != 'None' %}
+		<td class='searchProvider'>{{ links.link_search(entity) }}</td>
+	{% endif %}
 	<td class='track'>
 		<span class='artist_in_trackcolumn'>{{ links.links(entity.artists) }}</span> – {{ links.link(entity) }}
 	</td>

--- a/maloja/web/jinja/snippets/links.jinja
+++ b/maloja/web/jinja/snippets/links.jinja
@@ -57,3 +57,33 @@
 		{% endif %}
 	</a>
 {%- endmacro %}
+
+
+{% macro link_search(entity) -%}
+	{% set track = entity.title %}
+	{% set artists = entity.artists|join(', ') %}
+
+	{% if settings('TRACK_SEARCH_PROVIDER') == 'YouTube' %}
+		{% set provider = 'https://www.youtube.com/results?search_query=' %}
+	{% elif settings('TRACK_SEARCH_PROVIDER') == 'YouTube Music' %}
+		{% set provider = 'https://music.youtube.com/search?q=' %}
+	{% elif settings('TRACK_SEARCH_PROVIDER') == 'Spotify' %}
+		{% set provider = 'https://open.spotify.com/search/' %}
+	{% elif settings('TRACK_SEARCH_PROVIDER') == 'Tidal' %}
+		{% set provider = 'https://listen.tidal.com/search/tracks?q=' %}
+	{% elif settings('TRACK_SEARCH_PROVIDER') == 'SoundCloud' %}
+		{% set provider = 'https://soundcloud.com/search?q=' %}
+	{% elif settings('TRACK_SEARCH_PROVIDER') == 'Amazon Music' %}
+		{% set provider = 'https://music.amazon.com/search/' %}
+	{% elif settings('TRACK_SEARCH_PROVIDER') == 'Deezer' %}
+		{% set provider = 'https://www.deezer.com/search/' %}
+	{% elif settings('TRACK_SEARCH_PROVIDER') == 'Apple' %}
+		{% set provider = 'https://music.apple.com/us/search/song?term=' %}
+	{% else %}
+		{% set provider = 'https://www.google.com/search?q=' %}
+	{% endif %}
+
+	{% set icon = '<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" class="w-6 h-6" viewBox="0 0 20 20"><path d="M18 3a1 1 0 00-1.196-.98l-10 2A1 1 0 006 5v9.114A4.369 4.369 0 005 14c-1.657 0-3 .895-3 2s1.343 2 3 2 3-.895 3-2V7.82l8-1.6v5.894A4.37 4.37 0 0015 12c-1.657 0-3 .895-3 2s1.343 2 3 2 3-.895 3-2V3z"/></svg>' %}
+
+	<a href="{{ provider }}{{ artists }} {{ track }}">{{ icon }}</a>
+{%- endmacro %}

--- a/maloja/web/static/less/maloja.less
+++ b/maloja/web/static/less/maloja.less
@@ -497,9 +497,13 @@ table.list td.track span.artist_in_trackcolumn {
 	color:@TEXT_COLOR_SECONDARY;
 }
 
-table.list td.track a.trackProviderSearch {
-	margin-right: 5px;
-	padding: 0 10px;
+table.list td.searchProvider {
+	width: 20px;
+	padding-right: 5px;
+}
+
+table.list td.searchProvider:hover {
+	color: gold;
 }
 
 


### PR DESCRIPTION
Looks like this got lost in the change to jinja templates.
Removes Google Play Muisic (RIP 😞), adds Apple Music, fixes Spotify, and swaps the emoji for svg.

I was unable to get Maloja running on my local system from source (I still don't write python much - it wasn't pleased with importing globalconf) but I hacked it into [my running instance](https://scrobbles.z0.lt).