### PR TITLE
Add timezone support

### DIFF
--- a/maloja/data_files/config/settings/default.ini
+++ b/maloja/data_files/config/settings/default.ini
@@ -86,6 +86,10 @@ DISCOURAGE_CPU_HEAVY_STATS = false
 # Offset in hours to UTC
 TIMEZONE = 0
 
+# Timezone String - If set, overrides above offset
+# TIMEZONE_NAME = Pacific/Auckland
+TIMEZONE_NAME =
+
 [Fluff]
 
 # how many scrobbles a track needs to aquire this status

--- a/maloja/malojatime.py
+++ b/maloja/malojatime.py
@@ -4,10 +4,16 @@ from datetime import timezone, timedelta
 from calendar import monthrange
 from os.path import commonprefix
 import math
+import pytz
 from doreah.settings import get_settings
 
 
 OFFSET = get_settings("TIMEZONE")
+TZ_NAME = get_settings("TIMEZONE_NAME")
+if TZ_NAME != "":
+	TIMEZONE_DT = datetime.datetime.now(pytz.timezone(TZ_NAME))
+	OFFSET = TIMEZONE_DT.utcoffset().total_seconds()/60/60
+
 TIMEZONE = timezone(timedelta(hours=OFFSET))
 UTC = datetime.timezone.utc
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pip>=19.3
 jinja2>2.11
 lru-dict>=1.1.6
 css_html_js_minify
+pytz

--- a/settings.md
+++ b/settings.md
@@ -46,6 +46,8 @@ Settings File			| Environment Variable			| Type			| Description
 `DELIMITERS_INFORMAL`   | &nbsp;						| List (String)	| Delimiters in informal artist strings with spaces expected around them
 `DELIMITERS_FORMAL`   | &nbsp;						| List (String)	| Delimiters used to tag multiple artists when only one tag field is available
 **Web Interface**
+`TIMEZONE`  |   &nbsp;              | String | Timezone Offset (-8)
+`TIMEZONE_NAME`     | &nbsp;        | String | Timezone Name (Etc/UTC)
 `DEFAULT_RANGE_CHARTS_ARTISTS`	| &nbsp;				| String		| What range is shown per default for the tile view on the start page
 `DEFAULT_RANGE_CHARTS_TRACKS`	| &nbsp;				| String		| What range is shown per default for the tile view on the start page
 `DEFAULT_STEP_PULSE`	| &nbsp;				| String		| What steps are shown per default for the pulse view on the start page


### PR DESCRIPTION
My python is a bit rusty.. but this appears to work.  Won't affect any existing configs. Only sets it if you override the default empty TIMEZONE_NAME variable.

I just found it problematic with DST time having to change +12/+13

Ideally add extra try/catch and fallback to OFFSET in case of invalid TZ_NAME