### PR TITLE
Group LOONA subunits under a single group

### DIFF
--- a/maloja/data_files/config/rules/predefined/tdemin_kpop.tsv
+++ b/maloja/data_files/config/rules/predefined/tdemin_kpop.tsv
@@ -1,0 +1,13 @@
+# NAME: K-Pop
+# DESC: Groups various side projects together
+
+# LOONA
+belongtogether	LOOΠΔ / ODD EYE CIRCLE
+belongtogether	LOOΠΔ 1/3
+belongtogether	LOONA/yyxy
+countas	LOOΠΔ / ODD EYE CIRCLE	LOOΠΔ
+countas	LOOΠΔ 1/3	LOOΠΔ
+countas	LOONA/yyxy	LOOΠΔ
+countas	Chuu	LOOΠΔ
+countas	JinSoul	LOOΠΔ
+replaceartist	LOONA	LOOΠΔ


### PR DESCRIPTION
This creates a new ruleset fixing counting various subunits of [LOONA](http://loonatheworld.com/), a girl group under Blockberry Creative. Currently those count as separate groups due to the use of slash in the naming.

These rules are [confirmed](https://music.tdem.in/artist?artist=LOO%CE%A0%CE%94) to work with how Spotify currently names them and are subject to expansion in need.

![Maloja LOONA screenshot](https://user-images.githubusercontent.com/26599554/125616205-85032506-b2ec-4902-851c-d18ee1a93ccc.png)
