### PR TITLE
Load api keys before building database for api accessibility

### DIFF
--- a/maloja/database.py
+++ b/maloja/database.py
@@ -707,8 +707,8 @@ def start_db():
 	log("Starting database...")
 	global lastsync
 	lastsync = int(datetime.datetime.now(tz=datetime.timezone.utc).timestamp())
-	build_db()
 	loadAPIkeys()
+	build_db()
 	#run(dbserver, host='::', port=PORT, server='waitress')
 	log("Database reachable!")
 


### PR DESCRIPTION
Allows access to /mlj_1/test without database having to be built