### PR TITLE
Improve docker builds and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![](https://img.shields.io/pypi/v/malojaserver?style=for-the-badge)](https://pypi.org/project/malojaserver/)
 [![](https://img.shields.io/pypi/l/malojaserver?style=for-the-badge)](https://github.com/krateng/maloja/blob/master/LICENSE)
 [![](https://img.shields.io/codeclimate/maintainability/krateng/maloja?style=for-the-badge)](https://codeclimate.com/github/krateng/maloja)
+[![](https://img.shields.io/docker/pulls/krateng/maloja?style=for-the-badge)](https://hub.docker.com/r/krateng/maloja)
 
 
 Simple self-hosted music scrobble database to create personal listening statistics. No recommendations, no social network, no nonsense.
@@ -76,9 +77,26 @@ I can support you with issues best if you use **Alpine Linux**. In my experience
 
 ### Docker
 
-You can use the [Dockerhub build](https://hub.docker.com/r/krateng/maloja) or the dockerfile in this repository.
+All docker builds supply `MALOJA_SKIP_SETUP=yes` as a default environmental variable to make server startup non-interactive, which is necessary to make Maloja usable within a docker container.
 
-You might want to set the environment variables `MALOJA_FORCE_PASSWORD`, `MALOJA_SKIP_SETUP` and `MALOJA_DATA_DIRECTORY`.
+To configure Maloja use an ini file instead. Refer to the [settings documentation](settings.md) for available settings.
+
+Of note for docker users are these settings which should be passed as environmental variables to the container:
+
+* `MALOJA_DATA_DIRECTORY` -- Set the directory in the container where configuration folders/files should be located
+  * Mount a [volume](https://docs.docker.com/engine/reference/builder/#volume) to the specified directory to access these files outside the container (and to make them persistent)
+* `MALOJA_FORCE_PASSWORD` -- Set an admin password for maloja
+
+#### From Source
+
+The [`Dockerfile`](Dockerfile) builds Maloja from source. Images are available on [**Dockerhub**](https://hub.docker.com/r/krateng/maloja):
+
+* `latest` -- image is built from the `master` branch of this repository
+* `X.XX.XX` -- images are built from the [repository tags](https://github.com/krateng/maloja/tags) and *should* coincide with [pypi versions](https://pypi.org/project/malojaserver/) of maloja
+
+#### From PyPi
+
+Running a container using a [pypi version](https://pypi.org/project/malojaserver/) of maloja is possible using [`pip.Dockerfile`](pip.Dockerfile). Supply the version of Maloja you want to install with the `MALOJA_RELEASE` [ARG](https://docs.docker.com/engine/reference/builder/#arg)
 
 
 ## How to use

--- a/pip.Dockerfile
+++ b/pip.Dockerfile
@@ -4,31 +4,27 @@ FROM python:3-alpine
 # https://gitlab.com/Joniator/docker-maloja
 # https://github.com/Joniator
 
-WORKDIR /usr/src/app
+ARG MALOJA_RELEASE
 
-# Copy project into dir
-COPY . .
+WORKDIR /usr/src/app
 
 RUN apk add --no-cache --virtual .build-deps \
     gcc \
     libxml2-dev \
     libxslt-dev \
-    libc-dev \
-    # install pip3
     py3-pip \
-    linux-headers && \
+    libc-dev \
+    linux-headers \
+    && \
     pip3 install psutil && \
-    # use pip to install maloja project requirements
-    pip3 install --no-cache-dir -r requirements.txt && \
-    # use pip to install maloja as local project
-    pip3 install /usr/src/app && \
+    pip3 install malojaserver==$MALOJA_RELEASE && \
     apk del .build-deps
 
 RUN apk add --no-cache tzdata
 
+EXPOSE 42010
+
 # expected behavior for a default setup is for maloja to "just work"
 ENV MALOJA_SKIP_SETUP=yes
 
-EXPOSE 42010
-# use exec form for better signal handling https://docs.docker.com/engine/reference/builder/#entrypoint
 ENTRYPOINT ["maloja", "run"]


### PR DESCRIPTION
* Refactor Dockerfile to build from source instead of pypi
  * The project is eventually installed (locally in the container) using pip so the user gets the same experience as downloading from pip 
* Include an additional dockerfile for building from pypi
* Update readme documentation for docker to specify image sources and docker-specific run instructions

Resolves remaining issues from #90