### PR TITLE
Set Referrer-Policy to same-origin

### DIFF
--- a/maloja/web/jinja/abstracts/base.jinja
+++ b/maloja/web/jinja/abstracts/base.jinja
@@ -3,8 +3,10 @@
 <html>
 
 	<head>
-		<title>{% block title %}{% endblock %}</title>
 		<meta charset="UTF-8" />
+		<meta name="referrer" content="same-origin" />
+
+		<title>{% block title %}{% endblock %}</title>
 		<meta name="description" content='Maloja is a self-hosted music scrobble server.' />
 
 		<meta name="color-scheme" content="dark" />


### PR DESCRIPTION
Remove the Referer (sic) HTTP request header from external requests (e.g. to the image CDNs). Supported in all modern browsers. Let you keep your Maloja instance more private (unless you chose to share the URL).

The charset directive must be included in the first TCP packet. It should be set at the very top of the document. Grouping document mode metas and descriptive metadata in separate groups.