### PR TITLE
Build image for raspberry pi 2 (arm/v7)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,21 +20,12 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
-      - name: Login to GHCR
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@f2a13332ac1ce8c0a71aeac48a150dbb1838ab67
         with:
           images: |
             ${{ github.repository_owner }}/maloja
-            ghcr.io/${{ github.repository_owner }}/maloja
           # generate Docker tags based on the following events/attributes
           tags: |
             type=semver,pattern={{version}}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,7 +54,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 


### PR DESCRIPTION
Also dropped support for GHCR as it did not work for you for some reason.

Build is running right now. It looks like it's running in parallel no matter how many archs it is building for. I would expect that it won't take double time.

https://github.com/northys/maloja/runs/6147177580?check_suite_focus=true

I'll drop the last commit used to test it in my fork after it succeeds.