### PR TITLE
Add feature to parse remix artists

### DIFF
--- a/maloja/cleanup.py
+++ b/maloja/cleanup.py
@@ -178,7 +178,6 @@ class CleanerAgent:
 				# match remix in brackets
 				if re.match(r".*[\(\[](.*)" + filter + "[\)\]]", t):
 					artists += self.parseArtists(re.match(r".*[\(\[](.*)" + filter + "[\)\]]", t)[1])
-					print("check")
 
 				# match remix split with "-"
 				elif re.match(r".*-(.*)" + filter, t):

--- a/maloja/cleanup.py
+++ b/maloja/cleanup.py
@@ -172,6 +172,18 @@ class CleanerAgent:
 				return (title,artists)
 
 		artists = []
+
+		if malojaconfig["PARSE_REMIX_ARTISTS"]:
+			for filter in malojaconfig["FILTERS_REMIX"]:
+				# match remix in brackets
+				if re.match(r".*[\(\[](.*)" + filter + "[\)\]]", t):
+					artists += self.parseArtists(re.match(r".*[\(\[](.*)" + filter + "[\)\]]", t)[1])
+					print("check")
+
+				# match remix split with "-"
+				elif re.match(r".*-(.*)" + filter, t):
+					artists += self.parseArtists(re.match(r".*-(.*)" + filter, t)[1])
+
 		for st in self.rules_artistintitle:
 			if st in t.lower(): artists += self.rules_artistintitle[st].split("␟")
 		return (t,artists)

--- a/maloja/pkg_global/conf.py
+++ b/maloja/pkg_global/conf.py
@@ -181,7 +181,9 @@ malojaconfig = Configuration(
 			"remove_from_title":(tp.Set(tp.String()),							"Remove from Title",			["(Original Mix)","(Radio Edit)","(Album Version)","(Explicit Version)","(Bonus Track)"],	"Phrases that should be removed from song titles"),
 			"delimiters_feat":(tp.Set(tp.String()),								"Featuring Delimiters",			["ft.","ft","feat.","feat","featuring","Ft.","Ft","Feat.","Feat","Featuring"],				"Delimiters used for extra artists, even when in the title field"),
 			"delimiters_informal":(tp.Set(tp.String()),							"Informal Delimiters",			["vs.","vs","&"],																			"Delimiters in informal artist strings with spaces expected around them"),
-			"delimiters_formal":(tp.Set(tp.String()),							"Formal Delimiters",			[";","/","|","␝","␞","␟"],																					"Delimiters used to tag multiple artists when only one tag field is available")
+			"delimiters_formal":(tp.Set(tp.String()),							"Formal Delimiters",			[";","/","|","␝","␞","␟"],																					"Delimiters used to tag multiple artists when only one tag field is available"),
+			"filters_remix":(tp.Set(tp.String()),								"Remix Filters",				["remix", "Remix", "Remix Edit", "remix edit", "Short Mix", "short mix", "Extended Mix", "extended mix", "Soundtrack Version", "soundtrack version"],		"Filters used to recognize the remix artists in the title"),
+			"parse_remix_artists":(tp.Boolean(),								"Parse Remix Artists",			True)
 		},
 		"Web Interface":{
 			"default_range_charts_artists":(tp.Choice({'alltime':'All Time','year':'Year','month':"Month",'week':'Week'}),	"Default Range Artist Charts",	"year"),

--- a/maloja/pkg_global/conf.py
+++ b/maloja/pkg_global/conf.py
@@ -183,7 +183,7 @@ malojaconfig = Configuration(
 			"delimiters_informal":(tp.Set(tp.String()),							"Informal Delimiters",			["vs.","vs","&"],																			"Delimiters in informal artist strings with spaces expected around them"),
 			"delimiters_formal":(tp.Set(tp.String()),							"Formal Delimiters",			[";","/","|","␝","␞","␟"],																					"Delimiters used to tag multiple artists when only one tag field is available"),
 			"filters_remix":(tp.Set(tp.String()),								"Remix Filters",				["remix", "Remix", "Remix Edit", "remix edit", "Short Mix", "short mix", "Extended Mix", "extended mix", "Soundtrack Version", "soundtrack version"],		"Filters used to recognize the remix artists in the title"),
-			"parse_remix_artists":(tp.Boolean(),								"Parse Remix Artists",			True)
+			"parse_remix_artists":(tp.Boolean(),								"Parse Remix Artists",			False)
 		},
 		"Web Interface":{
 			"default_range_charts_artists":(tp.Choice({'alltime':'All Time','year':'Year','month':"Month",'week':'Week'}),	"Default Range Artist Charts",	"year"),


### PR DESCRIPTION
This feature adds automatic parsing of remix artists.

Right now remix artists have to be added by rules like:
```
artistintitle	Areia Remix			Areia
```

This PR parses remix artists in titles with `<title> (<artists> <filter>)` or `<title> - <artists> <filter>`.
This regex filter works for my database and shouldn't produce too many false positives. It can be disabled with `parse_remix_artists` and currently defaults to `True`.

`filters_remix` is currently set with `["remix", "Remix", "Remix Edit", "remix edit", "Short Mix", "short mix", "Extended Mix", "extended mix", "Soundtrack Version", "soundtrack version"]`.

## Examples
`Automne (French 79 Remix)` will correctly find `French 79`.


`We'll Be Coming Back - R3hab EDC NYC Remix` would be mistakenly parsed to `R3hab EDC NYC`. A `replaceartist` rule would be needed or `EDC NYC Remix`  has to be added to the filters.



