### PR TITLE
Track more additional information

### DIFF
--- a/maloja/apis/listenbrainz.py
+++ b/maloja/apis/listenbrainz.py
@@ -77,7 +77,7 @@ class Listenbrainz(APIHandler):
 					'track_title':titlestr,
 					'album_name':albumstr,
 					'scrobble_time':timestamp,
-					'duration': additional.get("duration"),
+					'scrobble_duration': additional.get("duration"),
 					**extrafields
 				},client=client)
 

--- a/maloja/apis/listenbrainz.py
+++ b/maloja/apis/listenbrainz.py
@@ -68,7 +68,7 @@ class Listenbrainz(APIHandler):
 					# fields that will not be consumed by regular scrobbling
 					# will go into 'extra'
 					k:additional[k]
-					for k in ['track_mbid', 'release_mbid', 'release_artist_name', 'artist_mbids','recording_mbid','tags', 'origin_url', 'spotify_id', 'music_service', 'music_service_name', 'submission_client']
+					for k in ['track_mbid', 'release_mbid', 'artist_mbids','recording_mbid','tags']
 					if k in additional
 				}
 

--- a/maloja/apis/listenbrainz.py
+++ b/maloja/apis/listenbrainz.py
@@ -68,7 +68,7 @@ class Listenbrainz(APIHandler):
 					# fields that will not be consumed by regular scrobbling
 					# will go into 'extra'
 					k:additional[k]
-					for k in ['release_mbid','artist_mbids','recording_mbid','tags']
+					for k in ['track_mbid', 'release_mbid','artist_mbids','recording_mbid','tags', 'spotify_id']
 					if k in additional
 				}
 
@@ -77,6 +77,7 @@ class Listenbrainz(APIHandler):
 					'track_title':titlestr,
 					'album_name':albumstr,
 					'scrobble_time':timestamp,
+					'track_length': additional.get("duration"),
 					**extrafields
 				},client=client)
 

--- a/maloja/apis/listenbrainz.py
+++ b/maloja/apis/listenbrainz.py
@@ -68,7 +68,7 @@ class Listenbrainz(APIHandler):
 					# fields that will not be consumed by regular scrobbling
 					# will go into 'extra'
 					k:additional[k]
-					for k in ['track_mbid', 'release_mbid','artist_mbids','recording_mbid','tags', 'spotify_id']
+					for k in ['track_mbid', 'release_mbid','artist_mbids','recording_mbid','tags', 'origin_url', 'spotify_id', 'music_service', 'music_service_name', 'submission_client']
 					if k in additional
 				}
 

--- a/maloja/apis/listenbrainz.py
+++ b/maloja/apis/listenbrainz.py
@@ -68,7 +68,7 @@ class Listenbrainz(APIHandler):
 					# fields that will not be consumed by regular scrobbling
 					# will go into 'extra'
 					k:additional[k]
-					for k in ['track_mbid', 'release_mbid','artist_mbids','recording_mbid','tags', 'origin_url', 'spotify_id', 'music_service', 'music_service_name', 'submission_client']
+					for k in ['track_mbid', 'release_mbid', 'release_artist_name', 'artist_mbids','recording_mbid','tags', 'origin_url', 'spotify_id', 'music_service', 'music_service_name', 'submission_client']
 					if k in additional
 				}
 
@@ -77,7 +77,7 @@ class Listenbrainz(APIHandler):
 					'track_title':titlestr,
 					'album_name':albumstr,
 					'scrobble_time':timestamp,
-					'track_length': additional.get("duration"),
+					'duration': additional.get("duration"),
 					**extrafields
 				},client=client)
 

--- a/maloja/apis/listenbrainz.py
+++ b/maloja/apis/listenbrainz.py
@@ -77,7 +77,7 @@ class Listenbrainz(APIHandler):
 					'track_title':titlestr,
 					'album_name':albumstr,
 					'scrobble_time':timestamp,
-					'scrobble_duration': additional.get("duration"),
+					'track_length': additional.get("duration"),
 					**extrafields
 				},client=client)
 


### PR DESCRIPTION
Track `duration` as per the API [spec](https://listenbrainz.readthedocs.io/en/latest/users/json.html#payload-json-details). Store `spotify_id` in extra
Added `track_mbid` which was requested in #149 
Sorry for the minimal PR changes.
