### PR TITLE
Add a rediscover feature

### DIFF
--- a/maloja/database/__init__.py
+++ b/maloja/database/__init__.py
@@ -337,6 +337,12 @@ def get_top_tracks(dbconn=None,**keys):
 	return results
 
 @waitfordb
+def get_rediscover(dbconn=None,**keys):
+	(since,to) = keys.get('timerange').timestamps()
+	result = sqldb.get_scrobbles_rediscover(since=since,to=to,dbconn=dbconn)
+	return result
+
+@waitfordb
 def artist_info(dbconn=None,**keys):
 
 	artist = keys.get('artist')

--- a/maloja/web/jinja/partials/rediscover_scrobbles.jinja
+++ b/maloja/web/jinja/partials/rediscover_scrobbles.jinja
@@ -1,0 +1,27 @@
+{% import 'snippets/links.jinja' as links %}
+{% import 'snippets/entityrow.jinja' as entityrow %}
+
+{% if scrobbles is undefined %}
+	{% set scrobbles = dbc.get_rediscover(filterkeys,limitkeys) %}
+{% endif %}
+
+{% set firstindex = amountkeys.page * amountkeys.perpage %}
+{% set lastindex = firstindex + amountkeys.perpage %}
+
+{% set maxbar = scrobbles[0]['scrobbles'] if scrobbles != [] else 0 %}
+<table class='list'>
+	{% for e in scrobbles %}
+		{% if loop.index0 >= firstindex and loop.index0 < lastindex %}
+		<tr>
+			<!-- Timestamp -->
+			<td class='time'>{{ malojatime.timestamp_desc(e["time"],short=shortTimeDesc) }}</td>
+			<!-- scrobbles -->
+			<td class="amount">{{ links.link_scrobbles([{'track':e.track,'timerange':limitkeys.timerange}],amount=e['scrobbles']) }}</td>
+			<td class="bar">{{ links.link_scrobbles([{'track':e.track,'timerange':limitkeys.timerange}],percent=e['scrobbles']*100/maxbar) }}</td>
+
+			<!-- artist -->
+			{{ entityrow.row(e['track']) }}
+		</tr>
+		{% endif %}
+	{% endfor %}
+</table>

--- a/maloja/web/jinja/rediscover.jinja
+++ b/maloja/web/jinja/rediscover.jinja
@@ -1,0 +1,54 @@
+{% extends "abstracts/base.jinja" %}
+{% block title %}Maloja - Rediscover{% endblock %}
+
+{% import 'snippets/links.jinja' as links %}
+
+{% block scripts %}
+	<script src="/datechange.js" async></script>
+{% endblock %}
+
+{% set scrobbles = dbc.get_rediscover(filterkeys,limitkeys) %}
+{% set pages = math.ceil(scrobbles.__len__() / amountkeys.perpage) %}
+{% if scrobbles[0] is defined %}
+	{% set toptrack = scrobbles[0].track %}
+	{% set img = images.get_track_image(toptrack) %}
+{% else %}
+	{% set img = "/favicon.png" %}
+{% endif %}
+
+
+{% block content %}
+
+<table class="top_info">
+	<tr>
+		<td class="image">
+			<div style="background-image:url('{{ img }}')"></div>
+		</td>
+		<td class="text">
+			<h1>Rediscover</h1>
+			{% if filterkeys.get('artist') is not none %}by {{ links.link(filterkeys.get('artist')) }}{% endif %}
+			<span>{{ limitkeys.timerange.desc(prefix=True) }}</span>
+			<br/>
+			<p class="stats">{{ scrobbles.__len__() }} Scrobbles</p>
+			<br/>
+			{% with delimitkeys = {} %}
+			{% include 'snippets/timeselection.jinja' %}
+			{% endwith %}
+
+		</td>
+	</tr>
+</table>
+
+{% if settings['CHARTS_DISPLAY_TILES'] %}
+	{% include 'partials/charts_tracks_tiles.jinja' %}
+	<br/><br/>
+{% endif %}
+
+{% with compare=true %}
+{% include 'partials/rediscover_scrobbles.jinja' %}
+{% endwith %}
+
+{% import 'snippets/pagination.jinja' as pagination %}
+{{ pagination.pagination(filterkeys,limitkeys,delimitkeys,amountkeys,pages) }}
+
+{% endblock %}


### PR DESCRIPTION
This feature helps to "rediscover"/find forgotten songs and is still WIP.
I often listen to songs in my last added playlist and never actually add them to a specific playlist.
After a few months I forget about the songs and their titles and try to find them in a libriary with 6000+ songs (which is quiet difficult).

I came up with the following query to find songs I haven't listened to for 2 month and have at least 3 scrobbles:
```sql
SELECT s.track_id, COUNT(s.track_id) as count, MAX(DATETIME(s.timestamp, 'unixepoch', 'localtime')) as last_played_date, s.rawscrobble 
FROM scrobbles as s
GROUP BY s.track_id 
HAVING count >= 3 AND last_played_date <= DATE('now', '-2 month')
ORDER BY last_played_date DESC, count DESC
```

I implemented a rough version under the `/rediscover` page and the user can pick a timestamp. Currently the scrobble count is hard coded to 3.
For example, if the user picks October 2022 (`/rediscover?in=2022/10`), all songs with at least 3 scrobbles and last played in October 2022 (including the selected month) and before are listed.


I used the `scrobbles.jinja` and `charts_tracks.jinja` as a starting point.

Things that should be fixed or maybe changed/added:
- [ ] Give the user an option to choose the sorting order. First last played timestamp or first scrobble count
- [ ] Give the user an option to choose the scrobble count limit
- [ ] Improve the timestamp picker for this use case
- [ ] Remove/Fix leftovers of used jinja templates
- [ ] Improve db request?
- [ ] Remove or fix scrobble count bar length (ca. 200px instead of 500px?) and fix padding