### PR TITLE
Fixed search response failure for manual scrobbling

### DIFF
--- a/maloja/web/static/js/manualscrobble.js
+++ b/maloja/web/static/js/manualscrobble.js
@@ -126,14 +126,14 @@ function searchresult_manualscrobbling() {
 		console.log(tracks);
 		for (let t of tracks) {
 			track = document.createElement("span");
-			trackstr = t["artists"].join(", ") + " - " + t["title"];
+			trackstr = t.track["artists"].join(", ") + " - " + t.track["title"];
 			tracklink = t["link"];
 			track.innerHTML = "<a href='" + tracklink + "'>" +  trackstr + "</a>";
 			row = document.createElement("tr")
 			col1 = document.createElement("td")
 			button = document.createElement("button")
 			button.innerHTML = "Scrobble!"
-			button.onclick = function(){ scrobble(t["artists"],t["title"])};
+			button.onclick = function(){ scrobble(t.track["artists"],t.track["title"])};
 			col2 = document.createElement("td")
 			row.appendChild(col1)
 			col1.appendChild(button)


### PR DESCRIPTION
Ive had a few failures with my scrobbler and wanted to manually scrobble at `/admin_manual` and noticed that when I do search it throw an error in the browser, the reason is that its not looking at t.track.