### PR TITLE
Fix AttributeError NoneType get when importing Maloja export

### DIFF
--- a/maloja/proccontrol/tasks/import_scrobbles.py
+++ b/maloja/proccontrol/tasks/import_scrobbles.py
@@ -351,7 +351,7 @@ def parse_maloja(inputf):
 				'track_title': s['track']['title'],
 				'track_artists': s['track']['artists'],
 				'track_length': s['track']['length'],
-				'album_name': s['track'].get('album',{}).get('name',''),
+				'album_name': s['track'].get('album',{}).get('albumtitle','') if s['track'].get('album') is not None else '',
 				'scrobble_time': s['time'],
 				'scrobble_duration': s['duration']
 			},'')


### PR DESCRIPTION
When importing a Maloja export created from [next_minor_version](/krateng/maloja/tree/next_minor_version) I was getting `AttributeError` like this from albums with None type:
```python
{
    'time': 1614101160, 
    'track': {
        'artists': ['SHINee'], 
        'title': "Don't Call Me", 
        'album': None, 
        'length': None
    }, 
    'duration': None, 
    'origin': 'import:lastfm'
} could not be parsed. Scrobble not imported. (AttributeError("'NoneType' object has no attribute 'get'"))
```

I'm not sure if anyone else gets this or if its a relevant change, but after fixing it I no longer get the errors while importing. 