### PR TITLE
Add a top album function to the native API

### DIFF
--- a/maloja/apis/native_v1.py
+++ b/maloja/apis/native_v1.py
@@ -314,7 +314,23 @@ def get_charts_tracks_external(**keys):
 		"list":result
 	}
 
+@api.get("charts/albums")
+@catch_exceptions
+@add_common_args_to_docstring(filterkeys=True,limitkeys=True)
+def get_charts_albums_external(**keys):
+	"""Returns album charts
 
+	:return: list (List)
+	:rtype: Dictionary"""
+	k_filter, k_time, _, _, _ = uri_to_internal(keys,forceArtist=True)
+	ckeys = {**k_filter, **k_time}
+
+	result = database.get_charts_albums(**ckeys)
+
+	return {
+		"status":"ok",
+		"list":result
+	}
 
 
 @api.get("pulse")

--- a/maloja/apis/native_v1.py
+++ b/maloja/apis/native_v1.py
@@ -400,7 +400,23 @@ def get_top_tracks_external(**keys):
 		"list":results
 	}
 
+@api.get("top/albums")
+@catch_exceptions
+@add_common_args_to_docstring(limitkeys=True,delimitkeys=True)
+def get_top_albums_external(**keys):
+	"""Returns respective number 1 albums in specified time frames
 
+	:return: list (List)
+	:rtype: Dictionary"""
+	_, k_time, k_internal, _, _ = uri_to_internal(keys)
+	ckeys = {**k_time, **k_internal}
+
+	results = database.get_top_albums(**ckeys)
+
+	return {
+		"status":"ok",
+		"list":results
+	}
 
 
 @api.get("artistinfo")

--- a/maloja/apis/native_v1.py
+++ b/maloja/apis/native_v1.py
@@ -322,7 +322,7 @@ def get_charts_albums_external(**keys):
 
 	:return: list (List)
 	:rtype: Dictionary"""
-	k_filter, k_time, _, _, _ = uri_to_internal(keys,forceArtist=True)
+	k_filter, k_time, _, _, _ = uri_to_internal(keys)
 	ckeys = {**k_filter, **k_time}
 
 	result = database.get_charts_albums(**ckeys)


### PR DESCRIPTION
This PR adds `/top/albums` to the API to follow `/top/tracks` and `/top/artists`. Thankfully, because of how maloja is written, this works immediately. Try out `/apis/mlj_1/top/albums?step=week`.