### PR TITLE
"stop" command - change to work on FreeBSD

### DIFF
--- a/maloja/__main__.py
+++ b/maloja/__main__.py
@@ -30,13 +30,13 @@ def print_header_info():
 
 def get_instance():
 	try:
-		return int(subprocess.check_output(["pgrep","-x","maloja"]))
+		return int(subprocess.check_output(["pgrep","-f","maloja$"]))
 	except Exception:
 		return None
 
 def get_instance_supervisor():
 	try:
-		return int(subprocess.check_output(["pgrep","-x","maloja_supervisor"]))
+		return int(subprocess.check_output(["pgrep","-f","maloja_supervisor"]))
 	except Exception:
 		return None
 


### PR DESCRIPTION
On FreeBSD maloja runs as a python3 process:

```
stuff 99477  0.0  0.7  97756  56176  5  IJ   08:29   0:00.68 python3: maloja_supervisor (python3.11)
stuff 99478  0.0  3.0 362092 249256  5  SJ   08:29   0:21.51 python3: maloja (python3.11)
```

this change updated the `pgrep` command to support FreeBSD. I guess / hope it work on Linux, too - but I dont have a Linux system to test it. Can you test it and maybe merge it?

If it does not work maybe we could add a check for the os and run the `-f` when it's running on FreeBSD?