### PR TITLE
Fix Listenbrainz API URL on admin page

### DIFF
--- a/maloja/web/jinja/admin_setup.jinja
+++ b/maloja/web/jinja/admin_setup.jinja
@@ -56,7 +56,7 @@
 
 	If you use a Chromium-based browser and listen to music on Plex, Spotify, Soundcloud, Bandcamp or YouTube Music, download the extension and simply enter the server URL as well as your API key in the relevant fields. They will turn green if the server is accessible.
 	<br/><br/>
-	You can also use any standard-compliant scrobbler. For GNUFM (audioscrobbler) scrobblers, enter <span class="stats"><span name="serverurl">yourserver.tld</span>/apis/audioscrobbler</span> as your Gnukebox server and your API key as the password. For Listenbrainz scrobblers, use <span class="stats"><span name="serverurl">yourserver.tld</span>/apis/listenbrainz</span> as the API URL and your API key as token.
+	You can also use any standard-compliant scrobbler. For GNUFM (audioscrobbler) scrobblers, enter <span class="stats"><span name="serverurl">yourserver.tld</span>/apis/audioscrobbler</span> as your Gnukebox server and your API key as the password. For Listenbrainz scrobblers, use <span class="stats"><span name="serverurl">yourserver.tld</span>/apis/listenbrainz/1</span> as the API URL and your API key as token.
 	<br/><br/>
 	If you use another browser or another music player, you could try to code your own extension. The API is super simple! Just send a POST HTTP request to
 


### PR DESCRIPTION
Add missing /1 to end of URL