### PR TITLE
Correct spaces to tabs in predefined rules

### DIFF
--- a/maloja/data_files/config/rules/predefined/krateng_kpopgirlgroups.tsv
+++ b/maloja/data_files/config/rules/predefined/krateng_kpopgirlgroups.tsv
@@ -160,8 +160,8 @@ replaceartist	여자친구 GFriend			GFriend
 # Girl's Generation
 replaceartist	소녀시대				Girls' Generation
 replaceartist	SNSD				Girls' Generation
-replaceartist Girls' Generation-TTS       TaeTiSeo
-countas       TaeTiSeo    Girls' Generation
+replaceartist	Girls' Generation-TTS	TaeTiSeo
+countas	TaeTiSeo	Girls' Generation
 
 # Apink
 replaceartist	A Pink					Apink


### PR DESCRIPTION
When doing some debugging on rule parsing, I noticed those two predefined rules have incorrect spacing.