### PR TITLE
Add get_first_scrobble function to db

### DIFF
--- a/maloja/database/__init__.py
+++ b/maloja/database/__init__.py
@@ -912,11 +912,9 @@ def start_db():
 	dbstatus['healthy'] = True
 
 	# inform time module about begin of scrobbling
-	try:
-		firstscrobble = sqldb.get_scrobbles()[0]
+	firstscrobble = sqldb.get_first_scrobble()
+	if firstscrobble is not None:
 		register_scrobbletime(firstscrobble['time'])
-	except IndexError:
-		register_scrobbletime(int(datetime.datetime.now().timestamp()))
 
 	dbstatus['complete'] = True
 

--- a/maloja/database/sqldb.py
+++ b/maloja/database/sqldb.py
@@ -965,6 +965,17 @@ def get_scrobbles(since=None,to=None,resolve_references=True,limit=None,reverse=
 
 	return result
 
+@cached_wrapper
+@connection_provider
+def get_first_scrobble(dbconn=None):
+	op = DB['scrobbles'].select().order_by(sql.asc('timestamp')).limit(1)
+	result = dbconn.execute(op).all()
+
+	if len(result):
+		return scrobbles_db_to_dict(result, dbconn=dbconn)[0]
+	else:
+		return None
+
 
 # we can do that with above and resolve_references=False, but just testing speed
 @cached_wrapper


### PR DESCRIPTION
On initialization of the database, there is a query that returns every scrobble just to get the timestamp for the very first one. This PR introduces a function to query the database directly to return only the single scrobble with the earliest timestamp.

Note that I removed the `else` branch for the case when there are no scrobbles. The global scrobbletime is already initialized to the current timestamp, making the `else` branch redundant.