### PR TITLE
add optional base64 image parameter to `newscrobble`

### DIFF
--- a/maloja/apis/native_v1.py
+++ b/maloja/apis/native_v1.py
@@ -596,6 +596,7 @@ def post_scrobble(
 		length:int=None,
 		time:int=None,
 		nofix=None,
+		image=None,
 		auth_result=None,
 		**extra_kwargs):
 	"""Submit a new scrobble.
@@ -609,6 +610,7 @@ def post_scrobble(
 	:param int length: Total length of the track in seconds. Optional.
 	:param int time: UNIX timestamp of the scrobble. Optional, not needed if scrobble is at time of request.
 	:param flag nofix: Skip server-side metadata parsing. Optional.
+	:param string image: Base64 encoded album art. Optional.
 
 	:return: status (String), track (Mapping)
 	:rtype: Dictionary
@@ -655,6 +657,22 @@ def post_scrobble(
 			{'type':'mixed_schema','value':['artist','artists'],
 			'desc':"These two fields are meant as alternative methods to submit information. Use of both is discouraged, but works at the moment."}
 		]
+	if image:
+		# Using the parameters supplied directly won't work because they aren't parsed
+		# for example, album artists will be all one big string instead of an array of strings
+		# we also need to check if the track has an album before we decide to give just the track the art
+		# so take details from `result`
+		albumartists = result['track']['album']['artists']
+		artists = result['track']['artists']
+		album = result['track']['album']['albumtitle']
+		title = result['track']['title']
+		if album:
+			# Album artists take priority, in case the album artist is different from the track artist
+			# We want the image to apply to the entire album
+			images.set_image(image,artists=albumartists or artists,albumtitle=album)
+		else:
+			# we could not find an album associated with this track
+			images.set_image(image,artists=artists,title=title)
 
 	if len(responsedict['warnings']) == 0: del responsedict['warnings']
 


### PR DESCRIPTION
## What?

I would like to add a new optional parameter to the scrobble API function `newscrobble` that allows (but does not require) a scrobble client to include a base64 encoded album/track art image alongside a scrobble.

## Why?

For example, many songs and albums on Bandcamp do not have their art stored on the usual sources like Deezer or Spotify. Scrobble clients that include album art alongside their scrobble requests can remove an extra manual step of having to download the album art and reupload it to maloja. I've had to do this many times and I've come up with this idea to automate the process.

**I've already added support for this feature to Web Scrobbler**: https://github.com/duckfromdiscord/web-scrobbler/commit/2dd879000929fe540124fff1ba13adb50963ffb6. I've tested it and it works, and I will open a PR there if this one is merged.

## How?

To use this, all a scrobble client has to do is encode an image in base64 and include it in the `image` parameter to `newscrobble`.

## Additional context

Let me know if there's anything I have to change to get this PR merged. I'm not 100% sure if all edge cases work, but I've tested a couple albums on Bandcamp that work. The edge cases I've tested are where album artists are not the same as track artists, and also tracks that have multiple artists. The way I've mitigated these issues is by using the parsed scrobble for info instead of the info provided directly to `newscrobble`.

Another way of doing this could be sending a URL from a scrobbler to maloja, but I chose not to do this because of possible malicious URLS (i.e. IP grabbers) and also because `images.set_image` already accepts base64.