### PR TITLE
Fixes Compliance Issue With ListenBrainz API

### DIFF
--- a/maloja/apis/listenbrainz.py
+++ b/maloja/apis/listenbrainz.py
@@ -79,7 +79,7 @@ class Listenbrainz(APIHandler):
 					'track_title':titlestr,
 					'album_title':albumstr,
 					'scrobble_time':timestamp,
-					'track_length': additional.get("duration"),
+					'track_length': additional.get("duration_ms") or additional.get("duration"),
 					**extrafields
 				},client=client)
 


### PR DESCRIPTION
According to [The Official ListenBrainz Documentation](https://listenbrainz.readthedocs.io/_/downloads/en/latest/pdf/) (page 89), the duration of a song is either `duration` and `duration_ms`, but not both. Maloja was only looking for `duration` and this caused issues with Navidrome as it reported `duration_ms` instead of `duration` so it would always be `null`. This would correct that issue.