### PR TITLE
Fix infinite scrobble loop with Navidrome

### DIFF
--- a/maloja/apis/listenbrainz.py
+++ b/maloja/apis/listenbrainz.py
@@ -27,7 +27,7 @@ class Listenbrainz(APIHandler):
 			InvalidMethodException: (200, {"code": 200, "error": "Invalid Method"}),
 			MalformedJSONException: (400, {"code": 400, "error": "Invalid JSON document submitted."}),
 			DuplicateScrobble: (200, {"status": "ok"}),
-			DuplicateTimestamp: (200, {"status": "ok"}),
+			DuplicateTimestamp: (409, {"error": "Scrobble with the same timestamp already exists."}),
 			Exception: (500, {"code": 500, "error": "Unspecified server error."})
 		}
 

--- a/maloja/apis/listenbrainz.py
+++ b/maloja/apis/listenbrainz.py
@@ -3,7 +3,7 @@ from ._exceptions import *
 from .. import database
 import datetime
 from ._apikeys import apikeystore
-from ..database.exceptions import DuplicateScrobble
+from ..database.exceptions import DuplicateScrobble, DuplicateTimestamp
 
 from ..pkg_global.conf import malojaconfig
 
@@ -27,6 +27,7 @@ class Listenbrainz(APIHandler):
 			InvalidMethodException: (200, {"code": 200, "error": "Invalid Method"}),
 			MalformedJSONException: (400, {"code": 400, "error": "Invalid JSON document submitted."}),
 			DuplicateScrobble: (200, {"status": "ok"}),
+			DuplicateTimestamp: (200, {"status": "ok"}),
 			Exception: (500, {"code": 500, "error": "Unspecified server error."})
 		}
 


### PR DESCRIPTION
When Maloja gets a `DuplicateTimestamp` error, the current behavior is to return a `500 Error` code. The way Navidrome handles this code is to [request the scrobble again](https://github.com/navidrome/navidrome/blob/master/core/agents/listenbrainz/agent.go#L101), and Maloja will keep returning `500` because it will have the same error. With this behavior, the scrobble with indefinitely be resent from Navidrome to Maloja(and then subsequently discarded), preventing any other scrobbles from Navidrome going through. The fix for this is to return `200 OK` instead of `500 Error` upon a `DuplicateTimestamp` error.

(Related: https://github.com/navidrome/navidrome/discussions/3664)