### PR TITLE
Read out mimetypes for cached images

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -22,7 +22,6 @@ RUN \
 		libxslt-dev \
 		libffi-dev \
 		libc-dev \
-		libmagic \
 		py3-pip \
 		linux-headers && \
   echo "" && \
@@ -30,6 +29,7 @@ RUN \
 	apk add --no-cache \
 		python3 \
 		py3-lxml \
+		libmagic \
 		tzdata && \
   echo "" && \
 	echo "**** install pip dependencies ****" && \

--- a/Containerfile
+++ b/Containerfile
@@ -22,6 +22,7 @@ RUN \
 		libxslt-dev \
 		libffi-dev \
 		libc-dev \
+		libmagic \
 		py3-pip \
 		linux-headers && \
   echo "" && \

--- a/maloja/server.py
+++ b/maloja/server.py
@@ -3,6 +3,7 @@ import os
 from threading import Thread
 from importlib import resources
 import time
+from magic import from_file
 
 
 # server stuff
@@ -154,7 +155,8 @@ def static_image(pth):
 
 @webserver.route("/cacheimages/<uuid>")
 def static_proxied_image(uuid):
-	return static_file(uuid,root=data_dir['cache']('images'))
+	mimetype = from_file(os.path.join(data_dir['cache']('images'),uuid),True)
+	return static_file(uuid,root=data_dir['cache']('images'),mimetype=mimetype)
 
 @webserver.route("/login")
 def login():

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ lru-dict==1.3.*
 psutil==5.9.*
 sqlalchemy==2.0
 python-datauri==3.0.*
+python-magic==0.4.*
 requests==2.32.*
 toml==0.10.*
 PyYAML==6.0.*


### PR DESCRIPTION
On Firefox, because there is no mimetype set when serving the file, it is served up as raw HTML, causing cached images to not be served to the client (as the fetch is aborted early). It doesn't appear to be an issue in Google Chrome.

This commit fixes #349 .