### PR TITLE
Include album title in proxy scrobbles

### DIFF
--- a/maloja/database/__init__.py
+++ b/maloja/database/__init__.py
@@ -114,8 +114,13 @@ def incoming_scrobble(rawscrobble,fix=True,client=None,api=None,dbconn=None):
 
 	if scrobbledict:
 
+		if 'album' in scrobbledict['track'] and 'albumtitle' in scrobbledict['track']['album']:
+			albumtitle = scrobbledict['track']['album']['albumtitle']
+		else:
+			albumtitle = None
+
 		sqldb.add_scrobble(scrobbledict,update_album=albumupdate,dbconn=dbconn)
-		proxy_scrobble_all(scrobbledict['track']['artists'],scrobbledict['track']['title'],scrobbledict['time'])
+		proxy_scrobble_all(scrobbledict['track']['artists'],scrobbledict['track']['title'],albumtitle,scrobbledict['time'])
 
 		dbcache.invalidate_caches(scrobbledict['time'])
 

--- a/maloja/thirdparty/__init__.py
+++ b/maloja/thirdparty/__init__.py
@@ -45,9 +45,9 @@ def import_scrobbles(identifier):
 			return service.import_scrobbles()
 	return False
 
-def proxy_scrobble_all(artists,title,timestamp):
+def proxy_scrobble_all(artists,title,album,timestamp):
 	for service in services["proxyscrobble"]:
-		service.scrobble(artists,title,timestamp)
+		service.scrobble(artists,title,album,timestamp)
 
 def get_image_track_all(track):
 	with thirdpartylock:
@@ -153,10 +153,10 @@ class ProxyScrobbleInterface(GenericInterface,abstract=True):
 			malojaconfig[self.proxyscrobble["activated_setting"]]
 		)
 
-	def scrobble(self,artists,title,timestamp):
+	def scrobble(self,artists,title,album,timestamp):
 		response = requests.post(
 			url=self.proxyscrobble["scrobbleurl"],
-			data=self.proxyscrobble_postdata(artists,title,timestamp),
+			data=self.proxyscrobble_postdata(artists,title,album,timestamp),
 			headers={
 				"User-Agent":self.useragent
 			}

--- a/maloja/thirdparty/lastfm.py
+++ b/maloja/thirdparty/lastfm.py
@@ -44,15 +44,20 @@ class LastFM(MetadataInterface, ProxyScrobbleInterface):
 	def proxyscrobble_parse_response(self,data):
 		return data.attrib.get("status") == "ok" and data.find("scrobbles").attrib.get("ignored") == "0"
 
-	def proxyscrobble_postdata(self,artists,title,timestamp):
-		return self.query_compose({
+	def proxyscrobble_postdata(self,artists,title,album,timestamp):
+		parameters = {
 			"method":"track.scrobble",
 			"artist[0]":", ".join(artists),
 			"track[0]":title,
 			"timestamp":timestamp,
 			"api_key":self.settings["apikey"],
 			"sk":self.settings["sk"]
-		})
+		}
+
+		if album is not None:
+			parameters["album[0]"] = album
+
+		return self.query_compose(parameters)
 
 	def authorize(self):
 		if all(self.settings[key] not in [None,"ASK",False] for key in ["username","password","apikey","secret"]):


### PR DESCRIPTION
I noticed that my proxied Last.fm scrobbles lacked the album title. This PR adjusts `proxy_scrobble_all`, `scrobble` and `proxyscrobble_postdata` to also submit the album title if set.