### PR TITLE
Hide names on tiles feature

### DIFF
--- a/maloja/pkg_global/conf.py
+++ b/maloja/pkg_global/conf.py
@@ -220,7 +220,7 @@ malojaconfig = Configuration(
 			"use_album_artwork_for_tracks":(tp.Boolean(),						"Use Album Artwork for tracks",	True),
 			"fancy_placeholder_art":(tp.Boolean(),								"Use fancy placeholder artwork",False),
 			"show_play_number_on_tiles":(tp.Boolean(),							"Show amount of plays on tiles",False),
-			"show_names_on_tiles":(tp.Boolean(),								"Show names on tiles",False),
+			"show_names_on_tiles":(tp.Boolean(),								"Show names on tiles",True),
 			"discourage_cpu_heavy_stats":(tp.Boolean(),							"Discourage CPU-heavy stats",	False,					"Prevent visitors from mindlessly clicking on CPU-heavy options. Does not actually disable them for malicious actors!"),
 			"use_local_images":(tp.Boolean(),									"Use Local Images",				True),
 			#"local_image_rotate":(tp.Integer(),									"Local Image Rotate",			3600),

--- a/maloja/pkg_global/conf.py
+++ b/maloja/pkg_global/conf.py
@@ -220,6 +220,7 @@ malojaconfig = Configuration(
 			"use_album_artwork_for_tracks":(tp.Boolean(),						"Use Album Artwork for tracks",	True),
 			"fancy_placeholder_art":(tp.Boolean(),								"Use fancy placeholder artwork",False),
 			"show_play_number_on_tiles":(tp.Boolean(),							"Show amount of plays on tiles",False),
+			"show_names_on_tiles":(tp.Boolean(),								"Show names on tiles",False),
 			"discourage_cpu_heavy_stats":(tp.Boolean(),							"Discourage CPU-heavy stats",	False,					"Prevent visitors from mindlessly clicking on CPU-heavy options. Does not actually disable them for malicious actors!"),
 			"use_local_images":(tp.Boolean(),									"Use Local Images",				True),
 			#"local_image_rotate":(tp.Integer(),									"Local Image Rotate",			3600),

--- a/maloja/web/jinja/partials/charts_albums_tiles.jinja
+++ b/maloja/web/jinja/partials/charts_albums_tiles.jinja
@@ -20,7 +20,9 @@
 			<div class="tile">
 			<a href="{{ links.url(album) }}">
 				<div class="lazy" data-bg="{{ images.get_album_image(album) }}"'>
-					<span class='stats'>#{{ rank }}</span> <span>{{ album.albumtitle }}</span>
+    					{% if settings['SHOW_NAMES_ON_TILES'] %}
+						<span class='stats'>#{{ rank }}</span> <span>{{ album.albumtitle }}</span>
+     					{% endif %}
 					{% if settings['SHOW_PLAY_NUMBER_ON_TILES'] %}
 						<p class="scrobbles"><span>{{ scrobbles }} {{ 'play' if scrobbles == 1 else 'plays' }}</span> </p>
 					{% endif %}

--- a/maloja/web/jinja/partials/charts_artists_tiles.jinja
+++ b/maloja/web/jinja/partials/charts_artists_tiles.jinja
@@ -20,7 +20,9 @@
 			<div class="tile">
 			<a href="{{ links.url(artist) }}">
 				<div class="lazy" data-bg="{{ images.get_artist_image(artist) }}"'>
-					<span class='stats'>#{{ rank }}</span> <span>{{ artist }}</span> 
+    					{% if settings['SHOW_NAMES_ON_TILES'] %}
+						<span class='stats'>#{{ rank }}</span> <span>{{ artist }}</span> 
+      					{% endif %}
 					{% if settings['SHOW_PLAY_NUMBER_ON_TILES'] %}
 						<p class="scrobbles"><span>{{ scrobbles }} {{ 'play' if scrobbles == 1 else 'plays' }}</span> </p>
 					{% endif %}

--- a/maloja/web/jinja/partials/charts_tracks_tiles.jinja
+++ b/maloja/web/jinja/partials/charts_tracks_tiles.jinja
@@ -20,7 +20,9 @@
 			<div class="tile">
 			<a href="{{ links.url(track) }}">
 				<div class="lazy" data-bg="{{ images.get_track_image(track) }}"'>
-					<span class='stats'>#{{ rank }}</span> <span>{{ track.title }}</span>
+					{% if settings['SHOW_NAMES_ON_TILES'] %}
+     						<span class='stats'>#{{ rank }}</span> <span>{{ track.title }}</span>
+	   				{% endif %}
 					{% if settings['SHOW_PLAY_NUMBER_ON_TILES'] %}
 						<p class="scrobbles"><span>{{ scrobbles }} {{ 'play' if scrobbles == 1 else 'plays' }}</span> </p>
 					{% endif %}


### PR DESCRIPTION
Hello, I propose a simple change to add an option to hide names (artist, track, album) on tile charts on the main page. 
This is very similar to the feature added in v3.2.2 - [Feature] Added option to show scrobbles on tile charts.

This would give users an option to have completely clean tile images on the main page if they so desire.

Thank you for your consideration.