### PR TITLE
Prevent start page modules from overlapping

### DIFF
--- a/maloja/web/static/css/startpage.css
+++ b/maloja/web/static/css/startpage.css
@@ -11,7 +11,7 @@ div#startpage {
 @media (min-width: 2201px) {
 	div#startpage {
 		grid-template-columns: repeat(6, 14vw);
-		grid-template-rows: repeat(2, 45vh);
+		grid-template-rows: repeat(2, minmax(45vh, max-content));
 		grid-column-gap: 2vw;
 
 		grid-template-areas:
@@ -23,7 +23,7 @@ div#startpage {
 @media (min-width: 1401px) and (max-width: 2200px) {
 	div#startpage {
 		grid-template-columns: repeat(2, 45vw);
-		grid-template-rows: repeat(3, 45vh);
+		grid-template-rows: repeat(2, minmax(45vh, max-content));
 
 		grid-template-areas:
 			"charts_artists lastscrobbles"

--- a/maloja/web/static/css/startpage.css
+++ b/maloja/web/static/css/startpage.css
@@ -23,7 +23,7 @@ div#startpage {
 @media (min-width: 1401px) and (max-width: 2200px) {
 	div#startpage {
 		grid-template-columns: repeat(2, 45vw);
-		grid-template-rows: repeat(2, minmax(45vh, max-content));
+		grid-template-rows: repeat(3, minmax(45vh, max-content));
 
 		grid-template-areas:
 			"charts_artists lastscrobbles"


### PR DESCRIPTION
This PR alters `startpage.css` to ensure that the minimum height of grid rows is adjusted to the intrinsic content size. This prevents overlapping of grid items when the screen height is very small.

Before:
![Screenshot_20250615_042607](https://github.com/user-attachments/assets/15f3ada9-c649-41cf-874b-bca97e954849)

After:
![Screenshot_20250615_042638](https://github.com/user-attachments/assets/1737b0f2-bdfe-4e6f-a75b-edaddfd3af90)
