### PR TITLE
Docker compose fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ If you would like to import your previous scrobbles, copy them into the import f
 
 * Have a look at the [available settings](settings.md) and specifiy your choices in `/etc/maloja/settings.ini`. You can also set each of these settings as an environment variable with the prefix `MALOJA_` (e.g. `MALOJA_SKIP_SETUP`).
 
-* If you have activated admin mode in your web interface, you can upload custom images for artists or tracks by simply dragging them onto the existing image on the artist or track page. You can also manage custom images directly in the file system - consult `images.info` in the `/var/lib/maloja/images` folder.
+* If you have activated admin mode in your web interface, you can upload custom images for artists or tracks by simply dragging them onto the existing image on the artist or track page. You can also manage custom images directly in the file system - consult `images.info` in the `/config/state/images` folder.
 
-* To specify custom rules, consult the `rules.info` file in `/etc/maloja/rules`. You can also apply some predefined rules on the `/admin_setup` page of your server.
+* To specify custom rules, consult the `rules.info` file in `/config/config/rules`. You can also apply some predefined rules on the `/admin_setup` page of your server.
 
 
 ## How to scrobble

--- a/example-compose.yml
+++ b/example-compose.yml
@@ -10,9 +10,9 @@ services:
     - "42010:42010"
     # different directories for configuration, state and logs
     volumes:
-    - "$PWD/config:/etc/maloja"
-    - "$PWD/data:/var/lib/maloja"
-    - "$PWD/logs:/var/log/maloja"
+    - "$PWD/config:/config/config"
+    - "$PWD/data:/config/state"
+    - "$PWD/logs:/config/logs"
     #you can also have everything together instead:
     #volumes:
     #- "$PWD/data:/data"


### PR DESCRIPTION
This addresses #373, which I also ran into while setting up Majola. This updates the example docker file and the README with the new paths that Majola is using.