### PR TITLE
Fixed an error importing Spotify data exports from 2025

### DIFF
--- a/maloja/proccontrol/tasks/import_scrobbles.py
+++ b/maloja/proccontrol/tasks/import_scrobbles.py
@@ -45,6 +45,10 @@ def import_scrobbles(inputf):
 	elif re.match(r"Streaming_History_Audio.+\.json", filename):
 		typeid,typedesc = "spotify", "Spotify"
 		importfunc = parse_spotify_lite
+        
+	elif re.match(r"StreamingHistory_music_[0-9]+\.json", filename):
+		typeid,typedesc = "spotify", "Spotify"
+		importfunc = parse_spotify_lite_legacy        
 
 	elif re.match(r"endsong_[0-9]+\.json", filename):
 		typeid,typedesc = "spotify", "Spotify"


### PR DESCRIPTION
Spotify data exports from 2025 are named differently than previously. The python script `import_scrobbles.py` did not recognise the updated file names from spotify. My recent Spotify export data was named `"StreamingHistory_music_0.json"`. 

I have editted the `import_scrobbles.py` script to recognise this new naming scheme from Spotify.

```
	elif re.match(r"StreamingHistory_music_[0-9]+\.json", filename):
		typeid,typedesc = "spotify", "Spotify"
		importfunc = parse_spotify_lite_legacy 
```