### PR TITLE
Handle duplicate scrobble/timestamps in Audioscrobbler APIs

### DIFF
--- a/maloja/apis/audioscrobbler.py
+++ b/maloja/apis/audioscrobbler.py
@@ -2,6 +2,7 @@ from ._base import APIHandler
 from ._exceptions import *
 from .. import database
 from ._apikeys import apikeystore
+from ..database.exceptions import DuplicateScrobble, DuplicateTimestamp
 
 class Audioscrobbler(APIHandler):
 	__apiname__ = "Audioscrobbler"
@@ -25,6 +26,8 @@ class Audioscrobbler(APIHandler):
 			InvalidAuthException: (401, {"error": 4, "message": "Invalid credentials"}),
 			InvalidMethodException: (200, {"error": 3, "message": "Invalid method"}),
 			InvalidSessionKey: (403, {"error": 9, "message": "Invalid session key"}),
+			DuplicateScrobble: (200, {"status": "ok"}),
+			DuplicateTimestamp: (409, {"error": 8, "message": "Scrobble with the same timestamp already exists."}),
 			Exception: (500, {"error": 8, "message": "Operation failed"})
 		}
 

--- a/maloja/apis/audioscrobbler_legacy.py
+++ b/maloja/apis/audioscrobbler_legacy.py
@@ -2,6 +2,7 @@ from ._base import APIHandler
 from ._exceptions import *
 from .. import database
 from ._apikeys import apikeystore
+from ..database.exceptions import DuplicateScrobble, DuplicateTimestamp
 
 from bottle import request
 
@@ -27,6 +28,8 @@ class AudioscrobblerLegacy(APIHandler):
 			InvalidAuthException: (403, "BADAUTH\n"),
 			InvalidMethodException: (400, "FAILED\n"),
 			InvalidSessionKey: (403, "BADSESSION\n"),
+			DuplicateScrobble: (200, "OK\n"),
+			DuplicateTimestamp: (409, "FAILED\n"),
 			Exception: (500, "FAILED\n")
 		}
 


### PR DESCRIPTION
Make Audioscrobbler APIs handle these exceptions in a way similar to [what the implementation for ListenBrainz does](https://github.com/krateng/maloja/blob/master/maloja/apis/listenbrainz.py#L29-L30).

I don't know if this is desired behaviour at all, but it fixed an issue I had with my client repeatedly scrobbling the same thing again and again that was already registered by the server.